### PR TITLE
changed service name for rhel systems

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: restart_ntp
   service:
-    name: ntp
+    name: '{{ ntp_daemon }}'
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- name: Include OS-specific variables.
+  include_vars: "{{ ansible_os_family }}.yml"
 
 - include: package.yml
   tags: package

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,5 @@
   notify: restart_ntp
   tags: configuration
 
-- name: start/stop NTP service
-  service:
-    name: ntp
-    state: '{{ ntp_service_state }}'
-    enabled: '{{ ntp_service_enabled }}'
+- include: service.yml
   tags: service

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Debian | enable service
+  service:
+    name: ntp
+    state: '{{ ntp_service_state }}'
+    enabled: '{{ ntp_service_enabled }}'
+  when: ansible_os_family == 'Debian'
+
+- name: RedHat | enable service
+  service:
+    name: ntpd
+    state: '{{ ntp_service_state }}'
+    enabled: '{{ ntp_service_enabled }}'
+  when: ansible_os_family == 'RedHat'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: Debian | enable service
+- name: Debian | enable service on debian-type distros
   service:
-    name: ntp
+    name: '{{ ntp_daemon }}'
     state: '{{ ntp_service_state }}'
     enabled: '{{ ntp_service_enabled }}'
   when: ansible_os_family == 'Debian'
 
-- name: RedHat | enable service
+- name: RedHat | enable service on rhel-type distros
   service:
-    name: ntpd
+    name: '{{ ntp_daemon }}'
     state: '{{ ntp_service_state }}'
     enabled: '{{ ntp_service_enabled }}'
   when: ansible_os_family == 'RedHat'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+ntp_daemon: ntp

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+ntp_daemon: ntpd


### PR DESCRIPTION
The service name for RHEL systems is different - it is ntpd, not ntp. Created service.yml and updated main.yml (following existing convention) to address this.
